### PR TITLE
[FEAT] Youtube API 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa' //
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -36,7 +36,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	// 스웨거
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2' //
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+	// Youtube API v3
+	implementation 'com.google.apis:google-api-services-youtube:v3-rev222-1.25.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/armagetdon/server/controller/YoutubeController.java
+++ b/src/main/java/com/armagetdon/server/controller/YoutubeController.java
@@ -1,0 +1,26 @@
+package com.armagetdon.server.controller;
+
+import com.armagetdon.server.dto.response.YoutubeDetail;
+import com.armagetdon.server.service.YoutubeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+@RestController
+@RequiredArgsConstructor
+public class YoutubeController {
+    private final YoutubeService youtubeService;
+
+    @GetMapping("/youtube")
+    private YoutubeDetail getYoutubeDetails(@RequestParam String youtubeUrl) {
+        try {
+            return youtubeService.getYoutubeDetails(youtubeUrl);
+        } catch (IOException | GeneralSecurityException e) {
+            e.printStackTrace();
+            return null;
+        }    }
+}

--- a/src/main/java/com/armagetdon/server/dto/response/YoutubeDetail.java
+++ b/src/main/java/com/armagetdon/server/dto/response/YoutubeDetail.java
@@ -1,0 +1,11 @@
+package com.armagetdon.server.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class YoutubeDetail {
+    private String title;
+    private String thumbnailUrl;
+}

--- a/src/main/java/com/armagetdon/server/service/YoutubeService.java
+++ b/src/main/java/com/armagetdon/server/service/YoutubeService.java
@@ -1,0 +1,66 @@
+package com.armagetdon.server.service;
+
+import com.armagetdon.server.dto.response.YoutubeDetail;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.youtube.YouTube;
+import com.google.api.services.youtube.model.VideoListResponse;
+import com.google.api.services.youtube.model.Video;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+public class YoutubeService {
+
+    @Value("${youtube.api.key}")
+    private String apiKey;
+
+
+    private static final String APPLICATION_NAME = "armageddon";
+
+    private final YouTube youtube;
+
+    public YoutubeService() throws GeneralSecurityException, IOException {
+        this.youtube = new YouTube.Builder(
+                GoogleNetHttpTransport.newTrustedTransport(),
+                JacksonFactory.getDefaultInstance(),
+                request -> {})
+                .setApplicationName(APPLICATION_NAME)
+                .build();
+    }
+
+    public YoutubeDetail getYoutubeDetails(String youtubeUrl) throws GeneralSecurityException, IOException {
+        String videoId = extractVideoId(youtubeUrl);
+
+        YouTube.Videos.List request = youtube.videos().list("snippet");
+        VideoListResponse response = request.setId(videoId).setKey(apiKey).execute();
+        List<Video> videoList = response.getItems();
+
+        // 잘못된 비디오 ID가 입력되었을 때
+        if (videoList.isEmpty()) {
+            //TODO: 예외처리
+        }
+
+        Video video = videoList.get(0);
+        String title = video.getSnippet().getTitle();
+        String thumbnailUrl = video.getSnippet().getThumbnails().getDefault().getUrl();
+        return new YoutubeDetail(title, thumbnailUrl);
+    }
+
+    private String extractVideoId(String videoUrl) {
+        String regex = "v=([^&]*)";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(videoUrl);
+
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
- Youtube API 연동
   - 의존성 추가
      ```
      	implementation 'com.google.apis:google-api-services-youtube:v3-rev222-1.25.0'
      ```
    - application.yml에 API key 추가

- 영상 정보 조회 서비스구현
   - param: YouTube url
   - response: YoutubeDetail 
      

- 영상 정보 조회 테스트 컨트롤러 구현 및 테스트
   
<img width="1079" alt="스크린샷 2024-07-04 오후 6 51 32" src="https://github.com/Armagetdon/Armagetdon_backend/assets/30834810/1cc34fe5-e129-4d50-a500-325d0ae41ec4">
